### PR TITLE
BUG: Can't click CTAs as they are blocked by gradient

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -40,7 +40,7 @@ const Hero = ({
                     <WatoVideo />
                 </div>
             )}
-            <div className="fixed z-10 h-screen w-screen bg-TopGradient" />
+            <div className="pointer-events-none fixed z-10 h-screen w-screen bg-TopGradient" />
             <div
                 className={`absolute inset-0 bg-black transition-all ${
                     fadeIn ? "opacity-80 ease-in" : " opacity-0"


### PR DESCRIPTION
Last PR we added a subtle black gradient to the top of the screen to make the navbar easier to see.

Unfortunately we did not disable pointer events, so nothing behind it could be clicked on.

This PR fixes this issue.