### PR TITLE
BUGFIX: Video goes full screen on mobile

### DIFF
--- a/components/WatoVideo.tsx
+++ b/components/WatoVideo.tsx
@@ -12,6 +12,7 @@ const WatoVideo = ({ transparent = false, gutter = false }: WatoVideoProps) => {
         >
             <video
                 autoPlay
+                playsInline
                 muted
                 loop
                 className={`absolute inset-0 h-full w-full object-cover`}


### PR DESCRIPTION
For some reason autoplay `video` tags bring the video fullscreen on mobile. The new html property should prevent that