### PR TITLE
[Bug] Job Form Multiselect Appears Below Footer

### DIFF
--- a/components/Form/FormMultiselect.tsx
+++ b/components/Form/FormMultiselect.tsx
@@ -78,7 +78,7 @@ const MultiSelectDropdown = ({
                         </span>
                     )}
                 </div>
-                <div className="pointer-events-none absolute max-h-60 w-full overflow-y-scroll border bg-white opacity-0 transition-opacity peer-checked:pointer-events-auto peer-checked:opacity-100">
+                <div className="pointer-events-none absolute z-50 max-h-60 w-full overflow-y-scroll rounded-md border bg-white opacity-0 transition-opacity peer-checked:pointer-events-auto peer-checked:opacity-100">
                     <ul ref={optionsListRef}>
                         {options.map((option) => {
                             return (

--- a/pages/careers/[id].tsx
+++ b/pages/careers/[id].tsx
@@ -28,7 +28,7 @@ const JobPosting = ({ postData }: JobPostingProps) => {
                     <h2>Apply for this position:</h2>
                 </div>
             </article>
-            <div className="flex flex-col items-center justify-center">
+            <div className="flex flex-col items-center justify-center pb-20">
                 <div className="md:w-[45rem] lg:w-[50rem] xl:w-[75rem]">
                     <JobForm id={postData.id}></JobForm>
                 </div>


### PR DESCRIPTION
Fixes an issue where the multiselect option list is rendered underneath the footer, getting cut off.  Also increases the spacing in the footer

## Old
![image](https://github.com/user-attachments/assets/f3827f55-343e-433c-b2e7-467acb4f45e4)
## New
![image](https://github.com/user-attachments/assets/86c63295-d4e5-4546-8d92-dfb8146dedd5)
