### PR TITLE
Add page title and meta description to Humanoid project page

### DIFF
--- a/pages/projects/humanoid.tsx
+++ b/pages/projects/humanoid.tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import Image from "next/image";
 import ContentPane from "../../components/ContentPane";
 import Hero from "../../components/Hero";
@@ -46,6 +47,13 @@ const PANE6_CONTENT = `Each 6 DOF leg is modeled, analyzed, and refined entirely
 const Humanoid = () => {
   return (
     <>
+      <Head>
+        <title>UWaterloo's First Humanoid Robot - Pioneer | WATonomous</title>
+        <meta
+          name="description"
+          content="Pioneer is UWaterloo's first humanoid robot, built by WATonomous: a fully custom bipedal platform with a 22 DOF hand, VR teleoperation, and in-house designed legs."
+        />
+      </Head>
       <Hero
         // image={imgpane00} //TODO change the image source in tailwind config
         title={PAGE_TITLE}

--- a/pages/projects/humanoid.tsx
+++ b/pages/projects/humanoid.tsx
@@ -51,7 +51,7 @@ const Humanoid = () => {
         <title>UWaterloo's First Humanoid Robot - Pioneer | WATonomous</title>
         <meta
           name="description"
-          content="Pioneer is UWaterloo's first humanoid robot, built by WATonomous: a fully custom bipedal platform with a 22 DOF hand, VR teleoperation, and in-house designed legs."
+          content="Pioneer is UWaterloo's first humanoid robot, built by WATonomous - 22 DOF hand, bimanual arm, and 12 DOF legs."
         />
       </Head>
       <Hero


### PR DESCRIPTION
## Summary
- Adds a `<Head>` tag with a descriptive `<title>` and meta description to the Humanoid project page
- Fixes Google search results showing the generic "projects - humanoid" title instead of "UWaterloo's First Humanoid Robot - Pioneer | WATonomous"